### PR TITLE
Add Workflows for Automated Release PR and Version Tagging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lumiastudios/code-guardians

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,34 @@
+name: release-pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Change to a new version
+        run: |
+          echo "${{ github.event.inputs.version }}" > VERSION
+
+      - name: Create a release pull request
+        uses: peter-evans/create-pull-request@v6.0.5
+        with:
+          author: "lumiastudios-bot <lumiastudios-bot@noreply.lumia.is>"
+          committer: "lumiastudios-bot <lumiastudios-bot@noreply.lumia.is>"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Release Databricks-Asset-Bundles-Deploy v${{ github.event.inputs.version }}
+          body: Release Databricks-Asset-Bundles-Deploy v${{ github.event.inputs.version }}
+          branch: release-v${{ github.event.inputs.version }}
+          title: 'Release Databricks-Asset-Bundles-Deploy v${{ github.event.inputs.version }}'
+          draft: false

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,0 +1,36 @@
+name: version-tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Tag new versions
+        shell: bash
+        run: |
+          set -e
+
+          commits=$(git log --pretty=format:"%h" ./VERSION)
+          for commit in $commits; do
+              version=$(git show $commit:./VERSION)
+              if [ -n "$(git tag -l "v${version}")" ]; then
+                  continue
+              fi
+
+              echo "Tagging $commit as v${version}"
+              git tag "v${version}" $commit
+          done
+
+      - name: Push new tags
+        shell: bash
+        run: git push --tags


### PR DESCRIPTION
This PR introduces two new GitHub workflows:

1. release-pr
- Adds a workflow to create a pull request for version releases.
- It allows manual triggering with a specified version and generates a VERSION file.
- The workflow then uses the create-pull-request action to create a pull request for the new version.
2. version-tag:
- Automates the tagging of new versions on the main branch.
- On each push to main, it reads the VERSION file, tags commits with the version number, and pushes the new tags.

Additional Changes:
- Added code owners for the repository.